### PR TITLE
Support email login without appending tenant domain for non-SaaS apps

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticator.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.application.authenticator.requestpath.basicauth.
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -94,6 +95,12 @@ public class BasicAuthRequestPathAuthenticator extends AbstractApplicationAuthen
             throw new AuthenticationFailedException("username and password cannot be empty", User.getUserFromUserName
                     (username));
         }
+
+        if (!IdentityUtil.isEmailUsernameValidationDisabled()) {
+            FrameworkUtils.validateUsername(username, context);
+            username = FrameworkUtils.preprocessUsername(username, context);
+        }
+
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
         ResolvedUserResult resolvedUserResult = FrameworkUtils.processMultiAttributeLoginIdentification(
                 MultitenantUtils.getTenantAwareUsername(username), tenantDomain);

--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticatorTest.java
@@ -176,6 +176,7 @@ public class BasicAuthRequestPathAuthenticatorTest  extends PowerMockIdentityBas
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         when(FrameworkUtils.processMultiAttributeLoginIdentification(dummyUserName,
                 MultitenantUtils.getTenantDomain(dummyUserName))).thenReturn(resolvedUserResult);
+        when(FrameworkUtils.preprocessUsername(dummyUserName, mockContext)).thenReturn(dummyUserName);
         mockStatic(User.class);
         mockStatic(MultitenantUtils.class);
         when(User.getUserFromUserName(dummyUserName)).thenReturn(new User());
@@ -228,6 +229,7 @@ public class BasicAuthRequestPathAuthenticatorTest  extends PowerMockIdentityBas
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
         when(FrameworkUtils.processMultiAttributeLoginIdentification(dummyUserName,
                 MultitenantUtils.getTenantDomain(dummyUserName))).thenReturn(resolvedUserResult);
+        when(FrameworkUtils.preprocessUsername(dummyUserName, mockContext)).thenReturn(dummyUserName);
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 
-        <carbon.identity.framework.version>5.20.3</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.200</carbon.identity.framework.version>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>


### PR DESCRIPTION
## Purpose
Support email login without appending tenant domain for non-SaaS apps. This PR is for Basic Auth Request Path Authentication flow.

Related to: wso2/product-is#12601
