### PR TITLE
Add changes to use the new login resolver concept

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/pom.xml
@@ -45,10 +45,6 @@
             <artifactId>org.wso2.carbon.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
-            <artifactId>pax-logging-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+            <artifactId>org.wso2.carbon.identity.login.resolver.mgt</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -133,7 +133,7 @@
                             org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.package.import.version.range}",
-                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            org.wso2.carbon.identity.login.resolver.mgt;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticator.java
@@ -33,7 +33,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.login.resolver.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -102,7 +102,7 @@ public class BasicAuthRequestPathAuthenticator extends AbstractApplicationAuthen
         }
 
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
-        ResolvedUserResult resolvedUserResult = FrameworkUtils.processMultiAttributeLoginIdentification(
+        ResolvedUserResult resolvedUserResult = FrameworkUtils.processLoginResolverIdentification(
                 MultitenantUtils.getTenantAwareUsername(username), tenantDomain);
         if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                 equals(resolvedUserResult.getResolvedStatus())) {

--- a/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.requestpath.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/requestpath/basicauth/BasicAuthRequestPathAuthenticatorTest.java
@@ -49,7 +49,7 @@ import org.wso2.carbon.identity.application.authenticator.requestpath.basicauth.
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.login.resolver.mgt.ResolvedUserResult;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -174,7 +174,7 @@ public class BasicAuthRequestPathAuthenticatorTest  extends PowerMockIdentityBas
 
         mockStatic(FrameworkUtils.class);
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
-        when(FrameworkUtils.processMultiAttributeLoginIdentification(dummyUserName,
+        when(FrameworkUtils.processLoginResolverIdentification(dummyUserName,
                 MultitenantUtils.getTenantDomain(dummyUserName))).thenReturn(resolvedUserResult);
         when(FrameworkUtils.preprocessUsername(dummyUserName, mockContext)).thenReturn(dummyUserName);
         mockStatic(User.class);
@@ -227,7 +227,7 @@ public class BasicAuthRequestPathAuthenticatorTest  extends PowerMockIdentityBas
         mockStatic(FrameworkUtils.class);
         when(FrameworkUtils.prependUserStoreDomainToName(dummyUserName)).thenReturn(dummyUserName);
         ResolvedUserResult resolvedUserResult = new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL);
-        when(FrameworkUtils.processMultiAttributeLoginIdentification(dummyUserName,
+        when(FrameworkUtils.processLoginResolverIdentification(dummyUserName,
                 MultitenantUtils.getTenantDomain(dummyUserName))).thenReturn(resolvedUserResult);
         when(FrameworkUtils.preprocessUsername(dummyUserName, mockContext)).thenReturn(dummyUserName);
         doAnswer(new Answer<Object>() {

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -90,6 +96,12 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
                 <version>${carbon.identity.framework.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -137,12 +149,6 @@
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <!-- Pax Logging -->
-            <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
-                <artifactId>pax-logging-api</artifactId>
-                <version>${pax.logging.api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -263,9 +269,6 @@
         <slf4j.api.version>1.7.12</slf4j.api.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.6</powermock.version>
-
-        <!-- Pax Logging Version -->
-        <pax.logging.api.version>1.10.1</pax.logging.api.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+                <artifactId>org.wso2.carbon.identity.login.resolver.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
@@ -238,7 +238,7 @@
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 
-        <carbon.identity.framework.version>5.20.200</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.83-SNAPSHOT</carbon.identity.framework.version>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>


### PR DESCRIPTION
## Purpose
> Add changes to use the new resolver concept which are introduced with the PRs https://github.com/wso2/carbon-identity-framework/pull/4404 and https://github.com/wso2-extensions/identity-governance/pull/652. Resolves: https://github.com/wso2/product-is/issues/15439.

## Goals
> The goal of this process is to make the WSO2 Identity Server extensible in-terms of having the ability to have multiple login resolvers and providing the user to select the login resolver to be executed from the user interface.

## Approach
> Deprecate the multi attribute specific login resolver since the introduction of the generic login resolver serves the same purpose with additional configurations to provide more extensibility.

## Release note
> This improvement will add the ability to resolve multiple login resolvers and add the changes to the new handler (alternative to the multi attribute login handler) so that the user can select a login resolver through the management console resident identity provider configurations. By default, the priority is provided to the login resolver that corresponds to the multi attribute login functionality. Users can introduce new login resolvers and decide on which resolver to be used.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-identity-framework/pull/4404, https://github.com/wso2-extensions/identity-governance/pull/652.

## Test environment
> Ubuntu 20.04.3 LTS, JDK 8.0.302, Maven 3.6.3 
 