### PR TITLE
Bump actions/cache version

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:


### PR DESCRIPTION
## Purpose
> Bump actions/cache version since v2 is deprecated.

## Related Issue 
- https://github.com/wso2/product-is/issues/23500